### PR TITLE
removes the function "playFreqM2M"

### DIFF
--- a/ev3_scratch.js
+++ b/ev3_scratch.js
@@ -216,17 +216,17 @@ function playStartUpTones()
     var tonedelay = 1000;
     setTimeout(function()
                       {
-                      playFreqM2M(262, 100);
+                      playFreq(262, 100, function(){});
                       }, tonedelay);
     
     setTimeout(function()
                       {
-                      playFreqM2M(392, 100);
+                      playFreq(392, 100, function(){});
                       }, tonedelay+150);
     
     setTimeout(function()
                       {
-                      playFreqM2M(523, 100);
+                      playFreq(523, 100, function(){});
                       }, tonedelay+300);
 }
 
@@ -732,21 +732,6 @@ function motor2(which, speed)
                                         + SET_MOTOR_START + motorBitField);
     
     return motorsOnCommand;
-}
-
-
-
-function playFreqM2M(freq, duration)
-{
-    console_log("playFreqM2M duration: " + duration + " freq: " + freq);
-    var volume = 100;
-    var volString = getPackedOutputHexString(volume, 1);
-    var freqString = getPackedOutputHexString(freq, 2);
-    var durString = getPackedOutputHexString(duration, 2);
-    
-    var toneCommand = createMessage(DIRECT_COMMAND_PREFIX + PLAYTONE + volString + freqString + durString);
-    
-    addToQueryQueue([TONE_QUERY, 0, null, toneCommand]);
 }
 
 function clearDriveTimer()


### PR DESCRIPTION
I wrote that function on the "testextension" repo to do the startup tones before I understood how callbacks worked, and I was confused in making a function with them. The code I'm merging here is from a more recent version of our "testextension" repo, and it works fine in doing the startup tones.

I don't think this changes anything performance-wise, as it's basically doing the same thing. It's more of a housekeeping thing - it's pointless to have a specific function that's the same as another but without a callback.